### PR TITLE
Several improvements to deploy button.

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -994,6 +994,7 @@ export class App extends PureComponent<Props, State> {
                   this.state.dialog?.type === DialogType.DEPLOY_ERROR
                 }
                 loadGitInfo={this.sendLoadGitInfoBackMsg}
+                wasSessionInfoInitialized={SessionInfo.isSet()}
               />
             </Header>
 

--- a/frontend/src/components/core/MainMenu/MainMenu.tsx
+++ b/frontend/src/components/core/MainMenu/MainMenu.tsx
@@ -113,6 +113,9 @@ export interface Props {
   closeDialog: () => void
 
   isDeployErrorModalOpen: boolean
+
+  /** Force the menu to re-render when session info is initialized, so the deploy button can update. */
+  wasSessionInfoInitialized: boolean
 }
 
 const getOpenInWindowCallback = (url: string) => (): void => {
@@ -254,7 +257,7 @@ function MainMenu(props: Props): ReactElement {
     if (gitState === GitStates.HEAD_DETACHED) {
       const dialog = DetachedHead()
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, getDeployAppUrl(gitInfo))
 
       return
     }
@@ -270,7 +273,7 @@ function MainMenu(props: Props): ReactElement {
     if (module && uncommittedFiles?.length) {
       const dialog = UncommittedChanges(module)
 
-      showDeployError(dialog.title, dialog.body)
+      showDeployError(dialog.title, dialog.body, getDeployAppUrl(gitInfo))
 
       return
     }

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/DetachedHead.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/DetachedHead.tsx
@@ -3,11 +3,11 @@ import { IDeployErrorDialog } from "./types"
 
 function DetachedHead(): IDeployErrorDialog {
   return {
-    title: "Unable to deploy app",
+    title: "Are you sure you want to deploy this app?",
     body: (
       <>
         <p>This Git tree is in a detached HEAD state.</p>
-        <p>Please commit the latest changes and push to Github to continue.</p>
+        <p>Please commit the latest changes and push to GitHub to continue.</p>
       </>
     ),
   }

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/ModuleIsNotAdded.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/ModuleIsNotAdded.tsx
@@ -7,9 +7,10 @@ function ModuleIsNotAdded(module: string): IDeployErrorDialog {
     body: (
       <>
         <p>
-          The file <code>{module}</code> has not been added to the repo.
+          This application's main file, <code>{module}</code>, is not being
+          tracked in this Git repo.
         </p>
-        <p>Please add it and push to Github to continue.</p>
+        <p>Please commit it and push to GitHub, then try again.</p>
       </>
     ),
   }

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/NoRepositoryDetected.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { ONLINE_DOCS_URL, TEAMS_URL } from "urls"
+import { SHARING_DOCS_URL, TEAMS_URL } from "urls"
 import { IDeployErrorDialog } from "./types"
 
 function NoRepositoryDetected(): IDeployErrorDialog {
@@ -7,14 +7,14 @@ function NoRepositoryDetected(): IDeployErrorDialog {
     title: "Unable to deploy app",
     body: (
       <>
-        <p>Could not find a remote repository hosted on Github.</p>
+        <p>Could not find a remote repository hosted on GitHub.</p>
         <p>How Streamlit sharing works:</p>
         <ul>
           <li>
-            To deploy a public app, you must first put it in a public Github
+            To deploy a public app, you must first put it in a public GitHub
             repo. See{" "}
             <a
-              href={ONLINE_DOCS_URL}
+              href={SHARING_DOCS_URL}
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/RepoIsAhead.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/RepoIsAhead.tsx
@@ -3,12 +3,12 @@ import { IDeployErrorDialog } from "./types"
 
 function RepoIsAhead(): IDeployErrorDialog {
   return {
-    title: "Unable to deploy app",
+    title: "Are you sure you want to deploy this app?",
     body: (
       <>
         <p>
           This Git repo has uncommitted changes. You may want to commit them
-          before continuing.
+          and push to GitHub before continuing.
         </p>
       </>
     ),

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/UncommittedChanges.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/UncommittedChanges.tsx
@@ -3,13 +3,13 @@ import { IDeployErrorDialog } from "./types"
 
 function UncommittedChanges(module: string): IDeployErrorDialog {
   return {
-    title: "Unable to deploy app",
+    title: "Are you sure you want to deploy this app?",
     body: (
       <>
         <p>
           The file <code>{module}</code> has uncommitted changes.
         </p>
-        <p>Please commit the latest changes and push to Github to continue.</p>
+        <p>Please commit the latest changes and push to GitHub to continue.</p>
       </>
     ),
   }

--- a/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/UntrackedFiles.tsx
+++ b/frontend/src/components/core/StreamlitDialog/DeployErrorDialogs/UntrackedFiles.tsx
@@ -3,16 +3,16 @@ import { IDeployErrorDialog } from "./types"
 
 function UntrackedFiles(): IDeployErrorDialog {
   return {
-    title: "Unable to deploy app",
+    title: "Are you sure you want to deploy this app?",
     body: (
       <>
         <p>
-          This Git repo has untracked files. You may want to commit them before
-          continuing.
+          This Git repo has untracked files. You may want to commit them and
+          push to GitHub before continuing.
         </p>
         <p>
           Alternatively, you can either delete the files (if they're not
-          needed) or add them to your <strong>.gitignore</strong>.
+          needed) or add them to your <code>.gitignore</code>.
         </p>
       </>
     ),

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -19,6 +19,8 @@ export const STREAMLIT_HOME_URL = "https://streamlit.io"
 export const DEPLOY_URL = "https://share.streamlit.io/deploy"
 export const STREAMLIT_SHARE_URL = "https://streamlit.io/sharing"
 export const ONLINE_DOCS_URL = "https://docs.streamlit.io"
+export const SHARING_DOCS_URL =
+  "https://docs.streamlit.io/en/stable/deploy_streamlit_app.html"
 export const COMMUNITY_URL = "https://discuss.streamlit.io"
 export const TEAMS_URL = "https://streamlit.io/for-teams"
 export const BUG_URL =

--- a/lib/streamlit/git_util.py
+++ b/lib/streamlit/git_util.py
@@ -3,8 +3,8 @@ import re
 from typing import Optional, Tuple
 
 # Github has two URLs, one that is https and one that is ssh
-GITHUB_HTTP_URL = r"^https://(www\.)?github.com/(.+)/(.+).git$"
-GITHUB_SSH_URL = r"^git@github.com:(.+)/(.+).git$"
+GITHUB_HTTP_URL = r"^https://(www\.)?github.com/(.+)/(.+)(?:.git)?$"
+GITHUB_SSH_URL = r"^git@github.com:(.+)/(.+)(?:.git)?$"
 
 # We don't support git < 2.7, because we can't get repo info without
 # talking to the remote server, which results in the user being prompted

--- a/lib/streamlit/report_session.py
+++ b/lib/streamlit/report_session.py
@@ -413,7 +413,11 @@ class ReportSession(object):
 
             self._repo = GitRepo(self._report.script_path)
 
-            repo, branch, module = self._repo.get_repo_info()
+            repo_info = self._repo.get_repo_info()
+            if repo_info is None:
+                return
+
+            repo, branch, module = repo_info
 
             msg.git_info_changed.repository = repo
             msg.git_info_changed.branch = branch


### PR DESCRIPTION
- Show dialog even when no '.git' at the end of the remote
- Update menu when sessionstate is set (fix dialog not showing)
- Always show "continue anyway" when there's a remote repo (this is a change in product spec)
- Several improvements to dialog strings
